### PR TITLE
Fix - We want the staging_path not the install_dir

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -371,7 +371,7 @@ class FPM::Package
       installdir = staging_path
     end
 
-    Find.find(installdir) do |path|
+    Find.find(staging_path) do |path|
       match_path = path.sub("#{installdir.chomp('/')}/", '')
 
       attributes[:excludes].each do |wildcard|


### PR DESCRIPTION
In testing - we really want the staging_path, not the installdir, since there can be some oddities in the way things are built:

fpm $FPMARGS \
    -d sysstat \
    --description "forwarder" --name "forwarder" \
    --after-install $ROOTDIR/forwarder/install.sh \
    --before-remove $ROOTDIR/forwarder/uninstall.sh \
    $ROOTDIR/forwarder=../../opt/
